### PR TITLE
fix(actor schema): handle missing nationality

### DIFF
--- a/src/import/schemas/actor.ts
+++ b/src/import/schemas/actor.ts
@@ -44,6 +44,6 @@ export const actorSchema = new Schema({
   nationality: {
     required: false,
     type: String,
-    use: { isValidCountryCode },
+    use: { isValidCountryCode: (code) => code === null || code === undefined || isValidCountryCode(code) },
   },
 });


### PR DESCRIPTION
- in the actor schema, `isValidCountryCode` would throw an error when the nationality was not defined, because it expected a string.

Since the nationality is not required in the db, the validator should allow the omission of the property. But as soon as it is present, `isValidCountryCode` will still be used, thus refusing empty strings.

Fixes #688 