### PR TITLE
refactor(getById): use getBulk when possible

### DIFF
--- a/src/graphql/mutations/image.ts
+++ b/src/graphql/mutations/image.ts
@@ -249,7 +249,7 @@ export default {
           const existingLabels = (await Image.getLabels(image)).map((l) => l._id);
 
           if (config.matching.applyActorLabels === true) {
-            const actors = (await mapAsync(actorIds, Actor.getById)).filter(Boolean) as Actor[];
+            const actors = await Actor.getBulk(actorIds);
             const labelIds = (await mapAsync(actors, Actor.getLabels))
               .flat()
               .map((label) => label._id);

--- a/src/graphql/mutations/scene.ts
+++ b/src/graphql/mutations/scene.ts
@@ -199,7 +199,7 @@ export default {
           const existingLabels = (await Scene.getLabels(scene)).map((l) => l._id);
 
           if (config.matching.applyActorLabels === true) {
-            const actors = (await mapAsync(actorIds, Actor.getById)).filter(Boolean) as Actor[];
+            const actors = await Actor.getBulk(actorIds);
             const labelIds = (await mapAsync(actors, Actor.getLabels)).flat().map((l) => l._id);
 
             logger.log("Applying actor labels to scene");

--- a/src/types/actor.ts
+++ b/src/types/actor.ts
@@ -49,6 +49,10 @@ export default class Actor {
     return actorCollection.get(_id);
   }
 
+  static async getBulk(_ids: string[]): Promise<Actor[]> {
+    return actorCollection.getBulk(_ids);
+  }
+
   static async getAll(): Promise<Actor[]> {
     return actorCollection.getAll();
   }
@@ -99,7 +103,7 @@ export default class Actor {
     const result = await searchActors(
       `query:'' sortBy:score sortDir:desc skip:${skip} take:${take}`
     );
-    return mapAsync(result.items, Actor.getById);
+    return await Actor.getBulk(result.items);
   }
 
   constructor(name: string, aliases: string[] = []) {

--- a/src/types/custom_field.ts
+++ b/src/types/custom_field.ts
@@ -47,6 +47,10 @@ export default class CustomField {
     return customFieldCollection.get(_id);
   }
 
+  static async getBulk(_ids: string[]): Promise<CustomField[]> {
+    return customFieldCollection.getBulk(_ids);
+  }
+
   static async getAll(): Promise<CustomField[]> {
     const fields = await customFieldCollection.getAll();
     return fields.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -102,6 +102,10 @@ export default class Image {
     return imageCollection.get(_id);
   }
 
+  static async getBulk(_ids: string[]): Promise<Image[]> {
+    return imageCollection.getBulk(_ids);
+  }
+
   static async getAll(): Promise<Image[]> {
     return imageCollection.getAll();
   }

--- a/src/types/label.ts
+++ b/src/types/label.ts
@@ -33,11 +33,15 @@ export default class Label {
 
   static async getForItem(id: string): Promise<Label[]> {
     const references = await LabelledItem.getByItem(id);
-    return (await mapAsync(references, (r) => Label.getById(r.label))).filter(Boolean) as Label[];
+    return await Label.getBulk(references.map((r) => r.label));
   }
 
   static async getById(_id: string): Promise<Label | null> {
     return await labelCollection.get(_id);
+  }
+
+  static async getBulk(_ids: string[]): Promise<Label[]> {
+    return await labelCollection.getBulk(_ids);
   }
 
   static async getAll(): Promise<Label[]> {

--- a/src/types/label.ts
+++ b/src/types/label.ts
@@ -1,5 +1,4 @@
 import { labelCollection, labelledItemCollection } from "../database";
-import { mapAsync } from "../utils/async";
 import { generateHash } from "../utils/hash";
 import * as logger from "../utils/logger";
 import LabelledItem from "./labelled_item";

--- a/src/types/marker.ts
+++ b/src/types/marker.ts
@@ -98,6 +98,10 @@ export default class Marker {
     return markerCollection.get(_id);
   }
 
+  static async getBulk(_ids: string[]): Promise<Marker[]> {
+    return markerCollection.getBulk(_ids);
+  }
+
   static async remove(_id: string): Promise<void> {
     await markerCollection.remove(_id);
   }

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -55,14 +55,17 @@ export default class Movie {
     return movieCollection.get(_id);
   }
 
+  static getBulk(_ids: string[]): Promise<Movie[]> {
+    return movieCollection.getBulk(_ids);
+  }
+
   static getAll(): Promise<Movie[]> {
     return movieCollection.getAll();
   }
 
   static async getByScene(id: string): Promise<Movie[]> {
-    return (
-      await mapAsync(await MovieScene.getByScene(id), (ms) => Movie.getById(ms.movie))
-    ).filter(Boolean) as Movie[];
+    const movieScenes = await MovieScene.getByScene(id);
+    return await Movie.getBulk(movieScenes.map((ms) => ms.movie));
   }
 
   static getByStudio(studioId: string): Promise<Movie[]> {
@@ -74,7 +77,7 @@ export default class Movie {
     const labelIds = [
       ...new Set((await mapAsync(scenes, Scene.getLabels)).flat().map((a) => a._id)),
     ];
-    return (await mapAsync(labelIds, Label.getById)).filter(Boolean) as Label[];
+    return await Label.getBulk(labelIds);
   }
 
   static async getActors(movie: Movie): Promise<Actor[]> {

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -169,9 +169,7 @@ export default class Scene {
 
       logger.log(`Found ${extractedActors.length} actors in scene path.`);
 
-      actors = (await mapAsync(extractedActors, (id: string) => Actor.getById(id))).filter(
-        Boolean
-      ) as Actor[];
+      actors = await Actor.getBulk(extractedActors);
 
       if (config.matching.applyActorLabels === true) {
         logger.log("Applying actor labels to scene");
@@ -368,6 +366,10 @@ export default class Scene {
 
   static async getById(_id: string): Promise<Scene | null> {
     return sceneCollection.get(_id);
+  }
+
+  static async getBulk(_ids: string[]): Promise<Scene[]> {
+    return sceneCollection.getBulk(_ids);
   }
 
   static async getAll(): Promise<Scene[]> {

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -20,7 +20,6 @@ import { onSceneCreate } from "../plugins/events/scene";
 import { enqueueScene } from "../queue/processing";
 import { updateActors } from "../search/actor";
 import { indexScenes } from "../search/scene";
-import { mapAsync } from "../utils/async";
 import { readdirAsync, rimrafAsync, statAsync, unlinkAsync } from "../utils/fs/async";
 import { generateHash } from "../utils/hash";
 import * as logger from "../utils/logger";

--- a/src/types/studio.ts
+++ b/src/types/studio.ts
@@ -40,6 +40,10 @@ export default class Studio {
     return studioCollection.get(_id);
   }
 
+  static async getBulk(_ids: string[]): Promise<Studio[]> {
+    return studioCollection.getBulk(_ids);
+  }
+
   static async getAll(): Promise<Studio[]> {
     return studioCollection.getAll();
   }
@@ -76,7 +80,7 @@ export default class Studio {
     const actorIds = [
       ...new Set((await mapAsync(scenes, Scene.getActors)).flat().map((a) => a._id)),
     ];
-    return (await mapAsync(actorIds, Actor.getById)).filter(Boolean) as Actor[];
+    return await Actor.getBulk(actorIds);
   }
 
   static async setLabels(studio: Studio, labelIds: string[]): Promise<void> {


### PR DESCRIPTION
- Replaces: from an array of ids, search each id individually, to map the results back to an array. Now: from an array of ids, search for all the ids in bulk
- As a byproduct, this greatly reduces the delay when searching for scenes in the web app, and building the image index on server startup. Other areas may also be sped up
- Examples: db with 7k scenes, 761 labels (localhost)
- - Search for scenes: ~1250ms to ~250ms
- - Image index build: ~250s to ~100s