### PR TITLE
refactor(scene): use seconds for timestamps in thumbnail generation

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -37,3 +37,44 @@ export function isValidUrl(str: string): boolean {
 export function libraryPath(str: string): string {
   return path.join(getConfig().persistence.libraryPath, "library", str);
 }
+
+/**
+ * Generates an array of timestamps at regular intervals
+ *
+ * @param count - the amount of timestamps to generate
+ * @param duration - the duration of the media. If given, will generate timestamps in seconds
+ * based on this duration. Otherwise, will generate in percentage strings
+ * @param options - generation options
+ * @param options.startPercentage - where to start the timestamp generation, as a percentage
+ * @param options.endPercentage - where to stop the timestamp generation, as a percentage
+ */
+export function generateTimestampsAtIntervals(
+  count: number,
+  duration: number | null = null,
+  options: { startPercentage: number; endPercentage: number } = {
+    startPercentage: 0,
+    endPercentage: 100,
+  }
+): string[] {
+  const timestamps: string[] = [];
+
+  let startPosition: number;
+  let endPosition: number;
+
+  if (duration) {
+    const secondsPerPercent = duration / 100;
+    startPosition = secondsPerPercent * options.startPercentage;
+    endPosition = secondsPerPercent * options.endPercentage;
+  } else {
+    startPosition = options.startPercentage;
+    endPosition = options.endPercentage;
+  }
+
+  const interval = (endPosition - startPosition) / count;
+
+  for (let i = 0; i < count; i++) {
+    timestamps.push(`${startPosition + interval * i}${duration ? "" : "%"}`);
+  }
+
+  return timestamps;
+}

--- a/test/utils/misc.fixtures.ts
+++ b/test/utils/misc.fixtures.ts
@@ -1,0 +1,38 @@
+export const generateTimestampsAtIntervals = [
+  {
+    count: 100,
+    duration: 100,
+    options: {
+      startPercentage: 0,
+      endPercentage: 100,
+    },
+    expected: new Array(100).fill(0).map((_, index) => `${(100 / 100) * index}`),
+  },
+  {
+    count: 100,
+    duration: 100,
+    options: {
+      startPercentage: 2,
+      endPercentage: 100,
+    },
+    expected: new Array(100).fill(0).map((_, index) => `${2 + ((100 - 2) / 100) * index}`),
+  },
+  {
+    count: 100,
+    duration: null,
+    options: {
+      startPercentage: 0,
+      endPercentage: 100,
+    },
+    expected: new Array(100).fill(0).map((_, index) => `${index.toString()}%`),
+  },
+  {
+    count: 100,
+    duration: null,
+    options: {
+      startPercentage: 2,
+      endPercentage: 100,
+    },
+    expected: new Array(100).fill(0).map((_, index) => `${2 + ((100 - 2) / 100) * index}%`),
+  },
+];

--- a/test/utils/misc.spec.ts
+++ b/test/utils/misc.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import { generateTimestampsAtIntervals } from '../../src/utils/misc';
+import * as fixtures from './misc.fixtures';
+
+describe("utils/misc", () => {
+  describe("generateTimestampsAtIntervals", () => {
+    for (const fixture of fixtures.generateTimestampsAtIntervals) {
+      it("generates correct timestamps", () => {
+        const timestamps = generateTimestampsAtIntervals(
+          fixture.count,
+          fixture.duration,
+          fixture.options
+        );
+        expect(timestamps).to.deep.equal(fixture.expected);
+      });
+    }
+  });
+});


### PR DESCRIPTION
- use timestamps in seconds, for generating previews & thumbnails
- - This should barely affect local files (since the durations are so short). But it will
be more noticeable on remote files, where the durations are longer.

Tested against preview generation:
![Screenshot from 2020-09-26 19-56-34](https://user-images.githubusercontent.com/17180727/94347190-74a0eb80-0032-11eb-9370-9e96a4fe4aa0.png)
