### PR TITLE
Fix: video player white background on tall screens

### DIFF
--- a/app/src/components/VideoPlayer.vue
+++ b/app/src/components/VideoPlayer.vue
@@ -493,6 +493,12 @@ export default class VideoPlayer extends Vue {
   position: relative;
   outline: none;
 
+  // Display the video in the vertical center
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background-color: #000000;
+
   &.hideControls {
     cursor: none;
   }

--- a/app/src/components/VideoPlayer.vue
+++ b/app/src/components/VideoPlayer.vue
@@ -141,7 +141,7 @@
           @click="togglePlay(false)"
           @dblclick="toggleFullscreen"
           id="video"
-          style="width: 100%"
+          class="video"
           ref="video"
         >
           <source :src="src" type="video/mp4" />
@@ -493,7 +493,7 @@ export default class VideoPlayer extends Vue {
   position: relative;
   outline: none;
 
-  // Display the video in the vertical center
+  // Vertically center the video
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -502,6 +502,12 @@ export default class VideoPlayer extends Vue {
   &.hideControls {
     cursor: none;
   }
+}
+
+.video {
+  // Make sure video does not overflow wrapper
+  height: 100%;
+  width: 100%;
 }
 
 .video-overlay {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "porn-vault",
-  "version": "0.24.0",
+  "version": "0.24.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- Centers the video vertically in the wrapper
- - Shouldn't change for 16:9 screens, but fixes for taller ones
- - Should fix #825 but I don't have an iPad, so this is just from simulating with Chrome 
- Fits the video height to the wrapper height.
- - On wider screens, the video would fit the width, and thus the top and bottom would be cut off
- - In the future, this could be a button in the player UI: to fit width or height (created #828)