### PR TITLE
refactor(Images): ctrl/shift selection

### DIFF
--- a/app/src/components/ImageCard.vue
+++ b/app/src/components/ImageCard.vue
@@ -8,7 +8,7 @@
       width="100%"
       height="100%"
       min-height="100px"
-      @click="$emit('open')"
+      @click="$emit('click', $event)"
       v-ripple
       :contain="contain"
     >

--- a/app/src/views/Images.vue
+++ b/app/src/views/Images.vue
@@ -45,7 +45,7 @@
             icon
             @click="favoritesOnly = !favoritesOnly"
           >
-            <v-icon>{{ favoritesOnly ? 'mdi-heart' : 'mdi-heart-outline' }}</v-icon>
+            <v-icon>{{ favoritesOnly ? "mdi-heart" : "mdi-heart-outline" }}</v-icon>
           </v-btn>
 
           <v-btn
@@ -53,7 +53,7 @@
             icon
             @click="bookmarksOnly = !bookmarksOnly"
           >
-            <v-icon>{{ bookmarksOnly ? 'mdi-bookmark' : 'mdi-bookmark-outline' }}</v-icon>
+            <v-icon>{{ bookmarksOnly ? "mdi-bookmark" : "mdi-bookmark-outline" }}</v-icon>
           </v-btn>
 
           <v-spacer></v-spacer>
@@ -99,7 +99,12 @@
           :items="sortDirItems"
         ></v-select>
 
-        <v-checkbox hide-details color="primary" v-model="largeThumbs" label="Large thumbnails"></v-checkbox>
+        <v-checkbox
+          hide-details
+          color="primary"
+          v-model="largeThumbs"
+          label="Large thumbnails"
+        ></v-checkbox>
       </v-container>
     </v-navigation-drawer>
 
@@ -142,7 +147,9 @@
           :xl="largeThumbs ? 4 : 2"
         >
           <ImageCard
-            :class="selectedImages.length && !selectedImages.includes(image._id) ? 'not-selected': ''"
+            :class="
+              selectedImages.length && !selectedImages.includes(image._id) ? 'not-selected' : ''
+            "
             width="100%"
             height="100%"
             @click="onImageClick(image, index, $event, false)"
@@ -227,8 +234,8 @@ import { imageModule } from "@/store/image";
     InfiniteLoading,
     ImageCard,
     Lightbox,
-    ImageUploader
-  }
+    ImageUploader,
+  },
 })
 export default class ImageList extends mixins(DrawerMixin) {
   addNewItem(image: IImage) {
@@ -255,16 +262,14 @@ export default class ImageList extends mixins(DrawerMixin) {
   lightboxIndex = null as number | null;
 
   tryReadLabelsFromLocalStorage(key: string) {
-    return (localStorage.getItem(key) || "")
-      .split(",")
-      .filter(Boolean) as string[];
+    return (localStorage.getItem(key) || "").split(",").filter(Boolean) as string[];
   }
 
   waiting = false;
   allLabels = [] as ILabel[];
   selectedLabels = {
     include: this.tryReadLabelsFromLocalStorage("pm_imageInclude"),
-    exclude: this.tryReadLabelsFromLocalStorage("pm_imageExclude")
+    exclude: this.tryReadLabelsFromLocalStorage("pm_imageExclude"),
   };
 
   onSelectedLabelsChange(val: any) {
@@ -297,40 +302,40 @@ export default class ImageList extends mixins(DrawerMixin) {
   sortDirItems = [
     {
       text: "Ascending",
-      value: "asc"
+      value: "asc",
     },
     {
       text: "Descending",
-      value: "desc"
-    }
+      value: "desc",
+    },
   ];
 
   sortBy = localStorage.getItem("pm_imageSortBy") || "relevance";
   sortByItems = [
     {
       text: "Relevance",
-      value: "relevance"
+      value: "relevance",
     },
     {
       text: "A-Z",
-      value: "name"
+      value: "name",
     },
     {
       text: "Added to collection",
-      value: "addedOn"
+      value: "addedOn",
     },
     {
       text: "Rating",
-      value: "rating"
+      value: "rating",
     },
     {
       text: "Bookmarked",
-      value: "bookmark"
+      value: "bookmark",
     },
     {
       text: "Random",
-      value: "$shuffle"
-    }
+      value: "$shuffle",
+    },
   ];
 
   favoritesOnly = localStorage.getItem("pm_imageFavorite") == "true";
@@ -381,7 +386,7 @@ export default class ImageList extends mixins(DrawerMixin) {
       // Use >= to include the currently clicked image, so it can be toggled
       // if necessary
       if (index >= lastSelectionImageIndex) {
-        for (let i = lastSelectionImageIndex; i <= index; i++) {
+        for (let i = lastSelectionImageIndex + 1; i <= index; i++) {
           this.selectImage(this.images[i]._id, nextSelectionState);
         }
       } else if (index < lastSelectionImageIndex) {
@@ -404,17 +409,17 @@ export default class ImageList extends mixins(DrawerMixin) {
         }
       `,
       variables: {
-        ids: this.selectedImages
-      }
+        ids: this.selectedImages,
+      },
     })
-      .then(res => {
+      .then((res) => {
         for (const id of this.selectedImages) {
-          this.images = this.images.filter(img => img._id != id);
+          this.images = this.images.filter((img) => img._id != id);
         }
         this.selectedImages = [];
         this.deleteSelectedImagesDialog = false;
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
       })
       .finally(() => {});
@@ -428,28 +433,20 @@ export default class ImageList extends mixins(DrawerMixin) {
         }
       `,
       variables: {
-        ids: [this.images[index]._id]
-      }
+        ids: [this.images[index]._id],
+      },
     })
-      .then(res => {
+      .then((res) => {
         this.images.splice(index, 1);
         this.lightboxIndex = null;
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
       })
       .finally(() => {});
   }
 
-  updateImage({
-    index,
-    key,
-    value
-  }: {
-    index: number;
-    key: string;
-    value: any;
-  }) {
+  updateImage({ index, key, value }: { index: number; key: string; value: any }) {
     const images = this.images[index];
     images[key] = value;
     Vue.set(this.images, index, images);
@@ -528,14 +525,11 @@ export default class ImageList extends mixins(DrawerMixin) {
       if (this.selectedLabels.exclude.length)
         exclude = "exclude:" + this.selectedLabels.exclude.join(",");
 
-      const query = `query:'${this.query ||
-        ""}' ${include} ${exclude} page:${this.page - 1} sortDir:${
-        this.sortDir
-      } take:${take} sortBy:${random ? "$shuffle" : this.sortBy} favorite:${
+      const query = `query:'${this.query || ""}' ${include} ${exclude} page:${
+        this.page - 1
+      } sortDir:${this.sortDir} take:${take} sortBy:${random ? "$shuffle" : this.sortBy} favorite:${
         this.favoritesOnly ? "true" : "false"
-      } bookmark:${this.bookmarksOnly ? "true" : "false"} rating:${
-        this.ratingFilter
-      }`;
+      } bookmark:${this.bookmarksOnly ? "true" : "false"} rating:${this.ratingFilter}`;
 
       const result = await ApolloClient.query({
         query: gql`
@@ -572,8 +566,8 @@ export default class ImageList extends mixins(DrawerMixin) {
         `,
         variables: {
           query,
-          seed: seed || localStorage.getItem("pm_seed") || "default"
-        }
+          seed: seed || localStorage.getItem("pm_seed") || "default",
+        },
       });
 
       return result.data.getImages;
@@ -583,16 +577,11 @@ export default class ImageList extends mixins(DrawerMixin) {
   }
 
   imageLink(image: any) {
-    return `${serverBase}/image/${image._id}?password=${localStorage.getItem(
-      "password"
-    )}`;
+    return `${serverBase}/image/${image._id}?password=${localStorage.getItem("password")}`;
   }
 
   labelAliases(label: any) {
-    return label.aliases
-      .slice()
-      .sort()
-      .join(", ");
+    return label.aliases.slice().sort().join(", ");
   }
 
   loadPage(page: number) {
@@ -600,15 +589,15 @@ export default class ImageList extends mixins(DrawerMixin) {
     this.selectedImages = [];
 
     this.fetchPage(page)
-      .then(result => {
+      .then((result) => {
         this.fetchError = false;
         imageModule.setPagination({
           numResults: result.numItems,
-          numPages: result.numPages
+          numPages: result.numPages,
         });
         this.images = result.items;
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
         this.fetchError = true;
       })
@@ -634,16 +623,16 @@ export default class ImageList extends mixins(DrawerMixin) {
             name
           }
         }
-      `
+      `,
     })
-      .then(res => {
+      .then((res) => {
         this.allLabels = res.data.getLabels;
         if (!this.allLabels.length) {
           this.selectedLabels.include = [];
           this.selectedLabels.exclude = [];
         }
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
       });
   }

--- a/app/src/views/Images.vue
+++ b/app/src/views/Images.vue
@@ -1,16 +1,27 @@
 <template>
   <v-container fluid>
     <BindTitle value="Images" />
-    <v-banner app sticky v-if="selectedImages.length">
+    <v-banner app sticky>
       {{ selectedImages.length }} images selected
       <template v-slot:actions>
-        <v-btn text @click="selectedImages = []" class="text-none">Deselect</v-btn>
+        <v-btn v-if="selectedImages.length" text @click="selectedImages = []" class="text-none"
+          >Deselect</v-btn
+        >
         <v-btn
+          v-else-if="!selectedImages.length"
+          text
+          @click="selectedImages = images.map((im) => im._id)"
+          class="text-none"
+          >Select all</v-btn
+        >
+        <v-btn
+          v-if="selectedImages.length"
           @click="deleteSelectedImagesDialog = true"
           text
           class="text-none"
           color="error"
-        >Delete</v-btn>
+          >Delete</v-btn
+        >
       </template>
     </v-banner>
 

--- a/app/src/views/Images.vue
+++ b/app/src/views/Images.vue
@@ -134,7 +134,7 @@
             :class="selectedImages.length && !selectedImages.includes(image._id) ? 'not-selected': ''"
             width="100%"
             height="100%"
-            @open="lightboxIndex = index"
+            @click="onImageClick(image, index, $event, false)"
             :image="image"
             :contain="true"
           >
@@ -142,8 +142,8 @@
               <v-checkbox
                 color="primary"
                 :input-value="selectedImages.includes(image._id)"
-                @change="selectImage(image._id)"
-                @click.native.stop
+                readonly
+                @click.native.stop="onImageClick(image, index, $event, true)"
                 class="mt-0"
                 hide-details
                 :contain="true"
@@ -332,12 +332,57 @@ export default class ImageList extends mixins(DrawerMixin) {
   isUploading = false;
 
   selectedImages = [] as string[];
+  lastSelectionImageId: string | null = null;
   deleteSelectedImagesDialog = false;
 
-  selectImage(id: string) {
-    if (this.selectedImages.includes(id))
-      this.selectedImages = this.selectedImages.filter(i => i != id);
-    else this.selectedImages.push(id);
+  isImageSelected(id: string) {
+    return !!this.selectedImages.find((selectedId) => id === selectedId);
+  }
+
+  selectImage(id: string, add: boolean) {
+    this.lastSelectionImageId = id;
+    if (add && !this.isImageSelected(id)) {
+      this.selectedImages.push(id);
+    } else {
+      this.selectedImages = this.selectedImages.filter((i) => i != id);
+    }
+  }
+
+  /**
+   * @param image - the clicked image
+   * @param index - the index of the image in the array
+   * @param event - the mouse click event
+   * @param forceSelectionChange - whether to force a selection change, instead of opening the image
+   */
+  onImageClick(image: IImage, index: number, event: MouseEvent, forceSelectionChange = true) {
+    // Use the last selected image or the current one, to allow toggling
+    // even when no previous selection
+    let lastSelectionImageIndex =
+      this.lastSelectionImageId !== null
+        ? this.images.findIndex((im) => im._id === this.lastSelectionImageId)
+        : index;
+    lastSelectionImageIndex = lastSelectionImageIndex === -1 ? index : lastSelectionImageIndex;
+
+    if (event.shiftKey) {
+      // Next state is opposite of the clicked image state
+      const nextSelectionState = !this.isImageSelected(image._id);
+
+      // Use >= to include the currently clicked image, so it can be toggled
+      // if necessary
+      if (index >= lastSelectionImageIndex) {
+        for (let i = lastSelectionImageIndex; i <= index; i++) {
+          this.selectImage(this.images[i]._id, nextSelectionState);
+        }
+      } else if (index < lastSelectionImageIndex) {
+        for (let i = lastSelectionImageIndex; i >= index; i--) {
+          this.selectImage(this.images[i]._id, nextSelectionState);
+        }
+      }
+    } else if (forceSelectionChange || event.ctrlKey) {
+      this.selectImage(image._id, !this.isImageSelected(image._id));
+    } else if (!forceSelectionChange) {
+      this.lightboxIndex = index;
+    }
   }
 
   deleteSelection() {


### PR DESCRIPTION
- Enable ctrl/shift selection to toggle selection states, when clicking **anywhere** on an image. Images can still be opened, when clicking anywhere except the checkbox, with ctrl/shift **not** held down.
- - Shift selection, will apply opposite state of the clicked image's current state, from the last clicked image (or the current clicked image, if no previous) to the current clicked image
- Always show selection banner.
- - Add 'Select all' button
Closes #482 