### PR TITLE
Fixed broken link to the bulk import doc page

### DIFF
--- a/doc/guides.md
+++ b/doc/guides.md
@@ -46,4 +46,4 @@ See https://github.com/boi123212321/porn-vault/blob/dev/doc/plugin_development.m
 
 ## Bulk import
 
-See the [bulk import doc](doc/import.md)
+See the [bulk import doc](import.md)


### PR DESCRIPTION
Link to the bulk import doc page is broken, this should fix it.