### PR TITLE
hotfix(plugins): import typescript

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,6 @@
+// typescript needs to be bundled with the executable
+import "typescript";
+
 import axios from "axios";
 import boxen from "boxen";
 import cheerio from "cheerio";


### PR DESCRIPTION
- `ts-node` uses a dynamic require to `typescript`, so `pkg` won't include it in the bundle. We can force pkg to include it, by simply importing it