### PR TITLE
adjust $walk

### DIFF
--- a/src/utils/fs/async.ts
+++ b/src/utils/fs/async.ts
@@ -1,5 +1,5 @@
 import { copyFile, mkdir, mkdirSync, readdir, readFile, rmdir, stat, unlink, writeFile } from "fs";
-import { extname, join, resolve } from "path";
+import { basename, extname, join, resolve } from "path";
 import { promisify } from "util";
 
 import * as logger from "../logger";
@@ -55,7 +55,7 @@ export async function walk(options: IWalkOptions): Promise<void> {
     for (const file of filesInDir) {
       const path = join(top, file);
 
-      if (pathIsExcluded(options.exclude, path)) {
+      if (pathIsExcluded(options.exclude, path) || basename(path).startsWith(".")) {
         logger.log(`"${path}" is excluded, skipping`);
         continue;
       }

--- a/src/utils/fs/async.ts
+++ b/src/utils/fs/async.ts
@@ -31,7 +31,7 @@ export interface IWalkOptions {
    * Return a truthy value to stop the walk. The return value will be the
    * path passed to the callback.
    */
-  cb: (file: string) => void | unknown;
+  cb: (file: string) => void | Promise<void | unknown> | unknown;
   exclude: string[];
 }
 

--- a/test/walk.spec.ts
+++ b/test/walk.spec.ts
@@ -29,6 +29,43 @@ describe("Walk folders", () => {
     });
   }
 
+  describe("acts as find", () => {
+    for (const value of [true, {}, []]) {
+      it(`stops after first call, when cb returns ${JSON.stringify(value)}`, async () => {
+        let cbCallCount = 0;
+
+        await walk({
+          dir: "test/fixtures/files",
+          exclude: [],
+          extensions: [".jpg"],
+          cb: async (path) => {
+            cbCallCount++;
+            return value;
+          },
+        });
+
+        expect(cbCallCount).to.equal(1);
+      });
+    }
+    for (const value of [false, null, undefined, 0, "", Number.NaN]) {
+      it(`does NOT stop after first call, when cb returns "${value}"`, async () => {
+        let cbCallCount = 0;
+
+        await walk({
+          dir: "test/fixtures/files",
+          exclude: [],
+          extensions: [".jpg"],
+          cb: async (path) => {
+            cbCallCount++;
+            return value;
+          },
+        });
+
+        expect(cbCallCount).to.be.greaterThan(1);
+      });
+    }
+  });
+
   // We cannot manipulate file modes properly on windows,
   // so do not run these tests
   if (os.type() !== "Windows_NT") {

--- a/test/walk.spec.ts
+++ b/test/walk.spec.ts
@@ -34,7 +34,7 @@ describe("Walk folders", () => {
       it(`stops after first call, when cb returns ${JSON.stringify(value)}`, async () => {
         let cbCallCount = 0;
 
-        await walk({
+        const res = await walk({
           dir: "test/fixtures/files",
           exclude: [],
           extensions: [".jpg"],
@@ -45,13 +45,14 @@ describe("Walk folders", () => {
         });
 
         expect(cbCallCount).to.equal(1);
+        expect(res).to.be.a('string');
       });
     }
     for (const value of [false, null, undefined, 0, "", Number.NaN]) {
       it(`does NOT stop after first call, when cb returns "${value}"`, async () => {
         let cbCallCount = 0;
 
-        await walk({
+        const res = await walk({
           dir: "test/fixtures/files",
           exclude: [],
           extensions: [".jpg"],
@@ -62,6 +63,7 @@ describe("Walk folders", () => {
         });
 
         expect(cbCallCount).to.be.greaterThan(1);
+        expect(res).to.be.undefined;
       });
     }
   });


### PR DESCRIPTION
- ignore dotfiles
- stop walk after first truthy value from callback (like Array.find)