### PR TITLE
fix: cannot set actor alt thumbnail

### DIFF
--- a/src/graphql/mutations/image.ts
+++ b/src/graphql/mutations/image.ts
@@ -1,6 +1,5 @@
 import { createWriteStream, ReadStream } from "fs";
 import Jimp from "jimp";
-import { extname } from "path";
 
 import { getConfig } from "../../config";
 import { ApplyActorLabelsEnum } from "../../config/schema";
@@ -18,6 +17,7 @@ import { mapAsync } from "../../utils/async";
 import { copyFileAsync, statAsync, unlinkAsync } from "../../utils/fs/async";
 import * as logger from "../../utils/logger";
 import { libraryPath } from "../../utils/path";
+import { getExtension } from "../../utils/string";
 import { Dictionary } from "../../utils/types";
 
 type IImageUpdateOpts = Partial<{
@@ -84,7 +84,7 @@ export default {
     const config = getConfig();
 
     const { filename, mimetype, createReadStream } = await args.file;
-    const ext = extname(filename);
+    const ext = getExtension(filename);
     const fileNameWithoutExtension = filename.split(".")[0];
 
     let imageName = fileNameWithoutExtension;

--- a/src/matching/wordMatcher.ts
+++ b/src/matching/wordMatcher.ts
@@ -1,8 +1,6 @@
-import path from "path";
-
 import { WordMatcherOptions } from "../config/schema";
 import { createObjectSet } from "../utils/misc";
-import { stripAccents } from "../utils/string";
+import { escapeRegExp, getExtension, stripAccents } from "../utils/string";
 import { ignoreSingleNames, isRegex, Matcher, MatchSource, REGEX_PREFIX } from "./matcher";
 
 const NORMALIZED_WORD_SEPARATOR = "-";
@@ -355,9 +353,9 @@ export class WordMatcher implements Matcher {
     sortByLongestMatch?: boolean
   ): T[] {
     let pathWithoutExt = this.options.ignoreDiacritics ? stripAccents(filePath) : filePath;
-    const pathExtension = path.extname(filePath);
+    const pathExtension = getExtension(filePath);
     if (pathExtension) {
-      pathWithoutExt = pathWithoutExt.replace(new RegExp(`${pathExtension}$`), "");
+      pathWithoutExt = pathWithoutExt.replace(new RegExp(`${escapeRegExp(pathExtension)}$`), "");
     }
 
     const pathParts = [...pathWithoutExt.split(this.filenameSeparatorRegex), pathExtension].filter(

--- a/src/utils/fs/async.ts
+++ b/src/utils/fs/async.ts
@@ -1,8 +1,9 @@
 import { copyFile, mkdir, mkdirSync, readdir, readFile, rmdir, stat, unlink, writeFile } from "fs";
-import { basename, extname, join, resolve } from "path";
+import { basename, join, resolve } from "path";
 import { promisify } from "util";
 
 import * as logger from "../logger";
+import { getExtension } from "../string";
 
 export const statAsync = promisify(stat);
 export const unlinkAsync = promisify(unlink);
@@ -22,7 +23,8 @@ export function mkdirpSync(path: string): string {
 const pathIsExcluded = (exclude: string[], path: string) =>
   exclude.some((regStr) => new RegExp(regStr, "i").test(path.toLowerCase()));
 
-const validExtension = (exts: string[], path: string) => exts.includes(extname(path).toLowerCase());
+const validExtension = (exts: string[], path: string) =>
+  exts.includes(getExtension(path).toLowerCase());
 
 export interface IWalkOptions {
   dir: string;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,12 +1,16 @@
-import { extname } from "path";
+const EXTENSION_REGEX = /(\.[^/.\s]+)$/;
+
+export function getExtension(file: string): string {
+  return EXTENSION_REGEX.exec(file)?.[0] || "";
+}
 
 export function extensionFromUrl(url: string): string {
   const clean = url.split("?")[0].split("#")[0];
-  return extname(clean);
+  return getExtension(clean) || "";
 }
 
 export function removeExtension(file: string): string {
-  return file.replace(/\.[^/.]+$/, "");
+  return file.replace(EXTENSION_REGEX, "");
 }
 
 /**
@@ -15,3 +19,12 @@ export function removeExtension(file: string): string {
  */
 export const stripAccents = (str: string): string =>
   str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ *
+ * @param string - input string
+ */
+export function escapeRegExp(string: string): string {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}

--- a/test/utils/fixtures/get_extension.fixture.ts
+++ b/test/utils/fixtures/get_extension.fixture.ts
@@ -1,0 +1,7 @@
+export default [
+  ["videofile.mp4", ".mp4"],
+  ["videofile", ""],
+  ["./somewhere/else/video.mp4", ".mp4"],
+  ["./somewhere/else/video", ""],
+  ["Elena Koshka (alt. thumbnail)", ""],
+];

--- a/test/utils/fixtures/remove_extension.fixture.ts
+++ b/test/utils/fixtures/remove_extension.fixture.ts
@@ -3,4 +3,5 @@ export default [
   ["videofile", "videofile"],
   ["./somewhere/else/video.mp4", "./somewhere/else/video"],
   ["./somewhere/else/video", "./somewhere/else/video"],
+  ["Elena Koshka (alt. thumbnail)", "Elena Koshka (alt. thumbnail)"],
 ];

--- a/test/utils/string.spec.ts
+++ b/test/utils/string.spec.ts
@@ -1,10 +1,19 @@
 import { expect } from "chai";
 
-import { removeExtension } from "../../src/utils/string";
+import { getExtension, removeExtension } from "../../src/utils/string";
+import getExtensionFixtures from "./fixtures/get_extension.fixture";
 import removeExtensionFixtures from "./fixtures/remove_extension.fixture";
 
 describe("utils", () => {
   describe("String utils", () => {
+    describe("getExtension", () => {
+      for (const test of getExtensionFixtures) {
+        it(`Should extract "${test[1]}" from "${test[0]}"`, () => {
+          expect(getExtension(test[0])).equals(test[1]);
+        });
+      }
+    });
+
     describe("removeExtension", () => {
       for (const test of removeExtensionFixtures) {
         it("Should work as expected", () => {


### PR DESCRIPTION
> Cant seem to set a alt thumbnail image. Can pick a file, choose the cropping area but when I set the viewport just refreshes and does not set the image.  In the console you get the lines:
  vault:success File written to tmp/im_khwdkgazyspWZe85.jpg. +0ms
  vault:success Image processing done. +0ms
but it's not followed by "vault:success Image 'Actor Name (alt thumb)' done." line like it does for setting any other image.
When setting any of the other image types the viewport closes after cropping the image but it does not show the updated image in the 'change actor images' dialogue until after a refresh.