### PR TITLE
Add page number to route `/scenes`

### DIFF
--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -56,6 +56,10 @@ const routes = [
   },
   {
     path: "/scenes",
+    redirect: "/scenes/1"
+  },
+  {
+    path: "/scenes/:page",
     name: "scenes",
     component: Scenes,
   },

--- a/app/src/views/Scenes.vue
+++ b/app/src/views/Scenes.vue
@@ -758,6 +758,7 @@ export default class SceneList extends mixins(DrawerMixin) {
           numPages: result.numPages,
         });
         this.scenes = result.items;
+        history.pushState({}, "", "#/scenes/" + page.toString());
       })
       .catch((err) => {
         console.error(err);
@@ -769,7 +770,8 @@ export default class SceneList extends mixins(DrawerMixin) {
   }
 
   refreshPage() {
-    this.loadPage(sceneModule.page);
+    this.page = Number(this.$route.params.page);
+    this.loadPage(Number(this.$route.params.page));
   }
 
   mounted() {


### PR DESCRIPTION
Adds the page number to  `/scenes` route, and handles history state, so you can go back / link to specific pages.

Closes #1087 

