### PR TITLE
Enhancement: check if actor exists before adding it to avoid duplicates

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -142,7 +142,12 @@ export async function loadStores(): Promise<void> {
     },
   ]);
 
-  actorCollection = await Izzy.createCollection("actors", libraryPath("actors.db"));
+  actorCollection = await Izzy.createCollection("actors", libraryPath("actors.db"), [
+    {
+      name: "name-index",
+      key: "name",
+    },
+  ]);
 
   movieCollection = await Izzy.createCollection("movies", libraryPath("movies.db"), [
     {

--- a/src/graphql/mutations/actor.ts
+++ b/src/graphql/mutations/actor.ts
@@ -74,8 +74,7 @@ export default {
       }
     } catch (error) {
       logger.warn(
-        `Error while checking if actor already exists: ${args.name}. You should probably lauch pv with option "--reset-izzy".` +
-          ` Actor creation will proceed normally, but you might end-up with duplicate actors.`
+        `Error while checking if actor exists: ${args.name}. Actor creation will proceed, but you might end-up with duplicates.`
       );
       logger.error(error);
     }

--- a/src/graphql/mutations/actor.ts
+++ b/src/graphql/mutations/actor.ts
@@ -65,6 +65,21 @@ export default {
     const config = getConfig();
     const aliases = filterInvalidAliases(args.aliases || []);
 
+    // If the actor already exists (same name), do not add it to avoid creating duplicates
+    try {
+      const existingActor = await Actor.getByName(args.name);
+      if (existingActor) {
+        logger.info(`Actor ${args.name} was not added as an actor with that name already exists.`);
+        return existingActor;
+      }
+    } catch (error) {
+      logger.warn(
+        `Error while checking if actor already exists: ${args.name}. You should probably lauch pv with option "--reset-izzy".` +
+          ` Actor creation will proceed normally, but you might end-up with duplicate actors.`
+      );
+      logger.error(error);
+    }
+
     let actor = new Actor(args.name, aliases);
 
     let actorLabels = [] as string[];

--- a/src/types/actor.ts
+++ b/src/types/actor.ts
@@ -106,6 +106,11 @@ export default class Actor {
     return actorCollection.get(_id);
   }
 
+  static async getByName(name: string): Promise<Actor | null> {
+    const actor = await actorCollection.query("name-index", encodeURIComponent(name));
+    return actor[0] as Actor | null;
+  }
+
   static async getBulk(_ids: string[]): Promise<Actor[]> {
     return actorCollection.getBulk(_ids);
   }

--- a/test/graphql/mutations/actor.spec.ts
+++ b/test/graphql/mutations/actor.spec.ts
@@ -59,6 +59,12 @@ describe("graphql", () => {
         await labelCollection.upsert(updateLabel._id, updateLabel);
         expect(await Label.getAll()).to.have.lengthOf(2);
 
+        const found = await Actor.getByName("abc actor");
+        expect(found).to.not.be.null;
+        if (found) {
+          expect(found.name).to.equal(seedActor.name);
+        }
+
         // Actor labels are not attached to scenes, since we manually set the labels
         expect(await Scene.getActors(sceneWithActorInPath)).to.have.lengthOf(0);
         expect(await Scene.getLabels(sceneWithActorInPath)).to.have.lengthOf(0);


### PR DESCRIPTION
Will not add an actor to the database if it already exists, therefore preventing a duplicate of the same actor to be made.

Existence is checked on "name", taking into account single names (as they are strictly resolved to the one actor with that single name), but not taking aliases into account (as it would lead to false positives).