### PR TITLE
fix: use env variable for config folder

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1,12 +1,14 @@
 ## Config
 
+> Some parameters that are essential to the program are defined via environment variables. [See here](https://github.com/porn-vault/porn-vault/blob/dev/doc/env.md) 
+
 If the program cannot find a config file, the program will go through an interactive setup, and then create a config file for you.
 
 > Note: not all settings will be prompted to the user, the rest will automatically taken from defaults, [that you can find here](https://github.com/porn-vault/porn-vault/blob/dev/config.example.json).
 
 ### Config location
 
-The config file must adjacent to the program itself, and can either be JSON or YAML. It must be named `config.json` or `config.yaml`. If both files exist, the program will use JSON over YAML.
+The config file must be located in the folder defined by the environment variable `PV_CONFIG_FOLDER` (usually the same folder as the program), and can either be JSON or YAML. It must be named `config.json` or `config.yaml`. If both files exist, the program will use JSON over YAML.
 
 ### Adjusting the config
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -79,7 +79,7 @@ The container requires some parameters for the app to run correctly. These param
 |               Parameter                | Function                                                                                                                                                                                                          |
 | :------------------------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |               `-p 3000`                | The port for the porn-vault webinterface. This must match what is in your config file.                                                                                                                            |
-|              `-v /config`              | Directory for persistent files (config file, database, backups...). It must be exactly this name.                                                   |
+|              `-v /config`              | Directory for persistent files (config file, database, backups...). Unless you changed the environment variable `PV_CONFIG_FOLDER`, it must be exactly this name.                                                    |
 |              `-v /videos`              | A directory for the `import.videos` config setting. The volume can have whatever path you want such as `/videos_from_drive_1` or `/videos_from_drive_2` _as long as you use that path in your config_.            |
 |              `-v /images`              | A directory for the `import.images` config The volume can have whatever path you want such as `/images_from_drive_1` or `/images_from_drive_2` _as long as you use that path in your config_.                     |
 
@@ -104,7 +104,7 @@ You could have a single volume such as `-v /my-stuff:/root_stuff` and then use i
 
 ## Notes
 
-When using Docker, the `binaries.ffmpeg` & `binaries.ffprobe` paths in the config must be valid, otherwise the program will exit. The images already have ffmpeg installed and thus use the following default paths:
+- When using Docker, the `binaries.ffmpeg` & `binaries.ffprobe` paths in the config must be valid, otherwise the program will exit. The images already have ffmpeg installed and thus use the following default paths:
 
 ```json
 {
@@ -114,6 +114,8 @@ When using Docker, the `binaries.ffmpeg` & `binaries.ffprobe` paths in the confi
   }
 }
 ```
+
+- By default, the images set the environment variable `PV_CONFIG_FOLDER=/config`, and create a volume for `/config`. Otherwise, you may run into permission or persistence issues.
 
 ## Integration with Elasticsearch
 

--- a/doc/env.md
+++ b/doc/env.md
@@ -6,7 +6,7 @@ simple options that don't need to be exposed to the user.
 The following environment variables are available:
 - `PV_CONFIG_FOLDER`
 - - Porn-vault will look for and store the config file, backups, binaries, logfiles, etc... in this folder.
-If not defined, it will fall back to the current working directory of the process (normally the same folder as th executable).
+If not defined, it will fall back to the current working directory of the process (normally the same folder as the executable).
 - `PV_LOG_LEVEL`
 - - The default log level used by the main (console) logger, before porn-vault loads the config file
 and uses the level defined in there. Default is `info`

--- a/doc/env.md
+++ b/doc/env.md
@@ -1,0 +1,15 @@
+## Environment variables
+
+Environment variables allow customizing some options that are required before even loading `config.json/yaml`, or
+simple options that don't need to be exposed to the user.  
+
+The following environment variables are available:
+- `PV_CONFIG_FOLDER`
+- - Porn-vault will look for and store the config file, backups, binaries, logfiles, etc... in this folder.
+If not defined, it will fall back to the current working directory of the process (normally the same folder as th executable).
+- `PV_LOG_LEVEL`
+- - The default log level used by the main (console) logger, before porn-vault loads the config file
+and uses the level defined in there. Default is `info`
+- `PV_QL_PLAYGROUND`
+- - Enables the GraphQL playground for the server's api. You can use this to easily test
+queries and/or do manual operations on your server. Default is `false`

--- a/doc/guides.md
+++ b/doc/guides.md
@@ -10,7 +10,7 @@
 
 ## Config
 
-See https://github.com/porn-vault/porn-vault/blob/dev/doc/config.md
+See [the config guide](https://github.com/porn-vault/porn-vault/blob/dev/doc/config.md) and [the environment variables guide](https://github.com/porn-vault/porn-vault/blob/dev/doc/env.md)
 
 ## How to run
 

--- a/doc/startup_options.md
+++ b/doc/startup_options.md
@@ -1,13 +1,15 @@
 ## Startup options
 
-These are arguments you can pass to the porn-vault executable to trigger a specific action upon startup.
+These are arguments you can pass to the porn-vault executable to trigger a specific action upon startup. This means you must run the executable in the terminal.
 
 - `--reindex`
 - - Deletes all porn-vault indices in elasticsearch and recreates them from scratch
 - `--reset-izzy`
 - - Kills and restarts Izzy, forcing it to reload the data from the .db files.  
-When Izzy is already running before porn-vault is started, it will retain it's data and the .db files will be restored from memory.
-If you want to reset your whole porn-vault installation and delete the .db files, you can use this option to prevent this.
+    When Izzy is already running before porn-vault is started, it will retain it's data and the .db files will be restored from memory.
+    If you want to reset your whole porn-vault installation and delete the .db files, you can use this option to prevent this.
+
+> Example usage: `porn-vault.exe --reindex`
 
 > When running from npm scripts, you can pass these options by adding an extra `--` after your command.  
-Example: `npm run mon -- --reindex`
+> Example: `npm run mon -- --reindex`

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -19,4 +19,5 @@ COPY ["config.example.json", "./docker/run.sh", "/"]
 
 VOLUME [ "/config"]
 EXPOSE 3000
+ENV PV_CONFIG_FOLDER=/config
 ENTRYPOINT ["/run.sh"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,4 +18,5 @@ COPY ["config.example.json", "./docker/run.sh", "/"]
 
 VOLUME [ "/config"]
 EXPOSE 3000
+ENV PV_CONFIG_FOLDER=/config
 ENTRYPOINT ["/run.sh"]

--- a/src/middlewares/apollo.ts
+++ b/src/middlewares/apollo.ts
@@ -11,7 +11,7 @@ export function mountApolloServer(app: express.Application): void {
       req,
     }),
     uploads: false,
-    playground: !!process.env.QL_PLAYGROUND,
+    playground: !!process.env.PV_QL_PLAYGROUND,
   });
   app.use(graphqlUploadExpress());
   server.applyMiddleware({ app, path: "/ql" });

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "fs";
 import path from "path";
 
 import { getConfig } from "../config";
@@ -7,18 +6,8 @@ export function libraryPath(str: string): string {
   return path.join(getConfig().persistence.libraryPath, "library", str);
 }
 
-export const isDocker = (function (): boolean {
-  try {
-    return readFileSync("/proc/self/cgroup", "utf8").includes("docker");
-  } catch (_) {
-    // Will only have error if not in a docker environment
-    return false;
-  }
-})();
+const configFolder = process.env.PV_CONFIG_FOLDER ? process.env.PV_CONFIG_FOLDER : process.cwd();
 
 export function configPath(...paths: string[]): string {
-  if (isDocker) {
-    return path.resolve(path.join("/config", ...paths));
-  }
-  return path.resolve(process.cwd(), ...paths);
+  return path.resolve(path.join(configFolder, ...paths));
 }


### PR DESCRIPTION
- Closes #1192
- Closes #1191 as a side effect
- Removes docker detection, in favor of environment variable: `PV_CONFIG_FOLDER`
- Rename `QL_PLAYGROUND` to `PV_QL_PLAYGROUND`