### PR TITLE
Fix scene thumbnail/screenshot name conflict

### DIFF
--- a/src/queue_loop.ts
+++ b/src/queue_loop.ts
@@ -52,7 +52,7 @@ export async function queueLoop(config: IConfig): Promise<void> {
         if (config.processing.generateScreenshots) {
           let screenshots = [] as ThumbnailFile[];
           try {
-            screenshots = await Scene.generateThumbnails(queueHead);
+            screenshots = await Scene.generateScreenshots(queueHead);
           } catch (error) {
             logger.error(error);
           }


### PR DESCRIPTION
- Fixes #1316 only for future generated thumbnails
The generated thumbnail path was found by searching for a file containing the scene id. The problem was that it would find the first generated screenshot since those files also contain the scene id.