### PR TITLE
fix: app bar would disappear when navigating backwards

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -82,10 +82,7 @@
       </v-btn>
 
       <template v-slot:extension v-if="showDetailsBar">
-        <scene-details-bar v-if="$route.name == 'scene-details'" />
-        <actor-details-bar v-else-if="$route.name == 'actor-details'" />
-        <movie-details-bar v-else-if="$route.name == 'movie-details'" />
-        <studio-details-bar v-else-if="$route.name == 'studio-details'" />
+        <component :is="detailsBarComponent"></component>
       </template>
     </v-app-bar>
 
@@ -116,10 +113,6 @@ import { sceneModule } from "./store/scene";
 import { actorModule } from "./store/actor";
 import { movieModule } from "./store/movie";
 import { studioModule } from "./store/studio";
-import SceneDetailsBar from "./components/AppBar/SceneDetails.vue";
-import ActorDetailsBar from "./components/AppBar/ActorDetails.vue";
-import MovieDetailsBar from "./components/AppBar/MovieDetails.vue";
-import StudioDetailsBar from "./components/AppBar/StudioDetails.vue";
 import { contextModule } from "./store/context";
 import moment from "moment";
 import { ensureDarkColor } from "./util/color";
@@ -127,10 +120,6 @@ import Footer from "./components/Footer.vue";
 
 @Component({
   components: {
-    SceneDetailsBar,
-    ActorDetailsBar,
-    MovieDetailsBar,
-    StudioDetailsBar,
     Footer,
   },
 })
@@ -167,17 +156,17 @@ export default class App extends Vue {
     return -1;
   }
 
-  get showDetailsBar() {
-    return (
-      this.$route.name == "scene-details" ||
-      this.$route.name == "actor-details" ||
-      this.$route.name == "studio-details" ||
-      this.$route.name == "movie-details"
-    );
+  get detailsBarComponent(): Vue | undefined {
+    const routeMeta = this.$route.meta as { detailsBarComponent?: Vue } | undefined;
+    return routeMeta?.detailsBarComponent;
+  }
+
+  get showDetailsBar(): boolean {
+    return !!this.detailsBarComponent;
   }
 
   @Watch("showDetailsBar")
-  onShowDetailsBarChange(show: boolean) {
+  onShowDetailsBarChange(show: boolean): void {
     if (!show) {
       // See https://github.com/vuetifyjs/vuetify/issues/12505
       this.$refs.appBar.isActive = true;

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
     <v-app-bar
+      ref="appBar"
       dark
       :hide-on-scroll="showDetailsBar"
       dense
@@ -134,6 +135,10 @@ import Footer from "./components/Footer.vue";
   },
 })
 export default class App extends Vue {
+  $refs!: {
+    appBar: Vue & { isActive: boolean };
+  };
+
   navDrawer = false;
 
   mounted() {
@@ -169,6 +174,14 @@ export default class App extends Vue {
       this.$route.name == "studio-details" ||
       this.$route.name == "movie-details"
     );
+  }
+
+  @Watch("showDetailsBar")
+  onShowDetailsBarChange(show: boolean) {
+    if (!show) {
+      // See https://github.com/vuetifyjs/vuetify/issues/12505
+      this.$refs.appBar.isActive = true;
+    }
   }
 
   get currentStudio() {

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -1,21 +1,24 @@
+import ActorDetailsBar from "@/components/AppBar/ActorDetails.vue";
+import MovieDetailsBar from "@/components/AppBar/MovieDetails.vue";
+import SceneDetailsBar from "@/components/AppBar/SceneDetails.vue";
+import StudioDetailsBar from "@/components/AppBar/StudioDetails.vue";
+import About from "@/views/About.vue";
+import ActorDetails from "@/views/ActorDetails.vue";
+import Actors from "@/views/Actors.vue";
+import Home from "@/views/Home.vue";
+import Images from "@/views/Images.vue";
+import Labels from "@/views/Labels.vue";
+import Markers from "@/views/Markers.vue";
+import MovieDetails from "@/views/MovieDetails.vue";
+import Movies from "@/views/Movies.vue";
+import Plugins from "@/views/Plugins.vue";
+import SceneDetails from "@/views/SceneDetails.vue";
+import Scenes from "@/views/Scenes.vue";
+import StudioDetails from "@/views/StudioDetails.vue";
+import Studios from "@/views/Studios.vue";
+import Views from "@/views/Views.vue";
 import Vue from "vue";
 import VueRouter from "vue-router";
-import Home from "../views/Home.vue";
-import About from "../views/About.vue";
-import Scenes from "../views/Scenes.vue";
-import Actors from "../views/Actors.vue";
-import Movies from "../views/Movies.vue";
-import SceneDetails from "../views/SceneDetails.vue";
-import ActorDetails from "../views/ActorDetails.vue";
-import MovieDetails from "../views/MovieDetails.vue";
-import StudioDetails from "../views/StudioDetails.vue";
-import Labels from "../views/Labels.vue";
-import Images from "../views/Images.vue";
-import Studios from "../views/Studios.vue";
-import Plugins from "../views/Plugins.vue";
-/* import Logs from "../views/Logs.vue"; */
-import Views from "../views/Views.vue";
-import Markers from "../views/Markers.vue";
 
 Vue.use(VueRouter);
 
@@ -78,21 +81,33 @@ const routes = [
     path: "/scene/:id",
     name: "scene-details",
     component: SceneDetails,
+    meta: {
+      detailsBarComponent: SceneDetailsBar,
+    },
   },
   {
     path: "/actor/:id",
     name: "actor-details",
     component: ActorDetails,
+    meta: {
+      detailsBarComponent: ActorDetailsBar,
+    },
   },
   {
     path: "/movie/:id",
     name: "movie-details",
     component: MovieDetails,
+    meta: {
+      detailsBarComponent: MovieDetailsBar,
+    },
   },
   {
     path: "/studio/:id",
     name: "studio-details",
     component: StudioDetails,
+    meta: {
+      detailsBarComponent: StudioDetailsBar,
+    },
   },
   {
     path: "/labels",


### PR DESCRIPTION
Closes #1274
- Enable the active status of the main app bar when navigating from a route where it was hidden to a route where it shouldn't
- Move the details app bar definition to the route's meta. Each route can simply add it's own app bar component in the meta. When the route is active:
- - the details app bar will automatically be rendered in App
- - the main app bar will be hidden on scroll