### PR TITLE
fix(mp4 transcode): only apply bitrate for amf windows

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -42,22 +42,3 @@ jobs:
           file: "./coverage/coverage-final.json"
           name: codecov
           fail_ci_if_error: true
-  test-windows:
-    timeout-minutes: 15
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - name: Runs Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@master
-        with:
-          stack-version: 7.9.0
-      - name: Test server
-        run: |
-          npm install
-          npm run coverage:silent
-        env:
-          CI: true

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -42,3 +42,22 @@ jobs:
           file: "./coverage/coverage-final.json"
           name: codecov
           fail_ci_if_error: true
+  test-windows:
+    timeout-minutes: 15
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 7.9.0
+      - name: Test server
+        run: |
+          npm install
+          npm run coverage:silent
+        env:
+          CI: true

--- a/test/testServer.ts
+++ b/test/testServer.ts
@@ -73,6 +73,7 @@ function cleanupFiles() {
 interface ExtraTestConfig {
   plugins?: Partial<IConfig["plugins"]>;
   matching?: Partial<IConfig["matching"]>;
+  transcode?: Partial<IConfig["transcode"]>;
 }
 
 export async function startTestServer(
@@ -97,6 +98,10 @@ export async function startTestServer(
       matching: {
         ...testConfig.matching,
         ...(extraConfig.matching || {}),
+      },
+      transcode: {
+        ...testConfig.transcode,
+        ...(extraConfig.transcode || {}),
       },
     };
 

--- a/test/transcode/mp4.spec.ts
+++ b/test/transcode/mp4.spec.ts
@@ -1,81 +1,121 @@
-import { before, Suite } from "mocha";
+import { Suite } from "mocha";
 import { FFProbeAudioCodecs, FFProbeVideoCodecs } from "../../src/ffmpeg/ffprobe";
 import Scene from "../../src/types/scene";
 import { expect } from "chai";
 import { startTestServer, stopTestServer } from "../testServer";
 import { MP4Transcoder } from "../../src/transcode/mp4";
+import { HardwareAccelerationDriver } from "../../src/config/schema";
+import * as os from "os";
 
 describe("transcoder", () => {
-  describe("mp4", function (this: Suite) {
-    before(async () => {
-      await startTestServer.call(this);
+  describe("mp4", () => {
+    describe("main tests", function (this: Suite) {
+      before(async () => {
+        await startTestServer.call(this);
+      });
+
+      after(() => {
+        stopTestServer();
+      });
+
+      it("copies the video stream", () => {
+        const scene = new Scene("test");
+        scene.meta.videoCodec = FFProbeVideoCodecs.H264;
+
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:v copy");
+      });
+
+      it("transcodes the video stream", () => {
+        const scene = new Scene("test") as Scene & { path: string };
+        scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
+
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:v libx264");
+      });
+
+      it("copies the audio stream", () => {
+        const scene = new Scene("test") as Scene & { path: string };
+        scene.meta.audioCodec = FFProbeAudioCodecs.AAC;
+
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:a copy");
+        expect(outputOptions).to.not.include("-c:a aac");
+      });
+
+      it("does not copy the audio stream", () => {
+        const scene = new Scene("test") as Scene & { path: string };
+        scene.meta.audioCodec = "unknown" as FFProbeAudioCodecs;
+
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:a aac");
+      });
+
+      it("validates requirements", () => {
+        const scene = new Scene("test");
+        scene.meta.videoCodec = FFProbeVideoCodecs.H264;
+
+        expect(new MP4Transcoder(scene).validateRequirements()).to.be.true;
+      });
+
+      it("validates requirements 2", () => {
+        const scene = new Scene("test");
+        scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
+
+        expect(new MP4Transcoder(scene).validateRequirements()).to.be.true;
+      });
     });
 
-    after(() => {
-      stopTestServer();
-    });
+    describe("unique cases", () => {
+      afterEach(() => {
+        stopTestServer();
+      });
 
-    it("copies the video stream", () => {
-      const scene = new Scene("test");
-      scene.meta.videoCodec = FFProbeVideoCodecs.H264;
+      it("does not transcode when compatible", async function () {
+        await startTestServer.call(this, {
+          transcode: { hwaDriver: HardwareAccelerationDriver.enum.vaapi },
+        });
 
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions).to.include("-c:v copy");
-    });
+        const scene = new Scene("test") as Scene & { path: string };
 
-    it("transcodes the video stream", () => {
-      const scene = new Scene("test") as Scene & { path: string };
-      scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
+        scene.meta.videoCodec = FFProbeVideoCodecs.H264;
 
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions).to.include("-c:v libx264");
-    });
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.not.include("-c:v h264_vaapi");
+      });
 
-    it("copies the audio stream", () => {
-      const scene = new Scene("test") as Scene & { path: string };
-      scene.meta.audioCodec = FFProbeAudioCodecs.AAC;
+      it("transcodes using selected driver", async function () {
+        await startTestServer.call(this, {
+          transcode: { hwaDriver: HardwareAccelerationDriver.enum.vaapi },
+        });
 
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions).to.include("-c:a copy");
-      expect(outputOptions).to.not.include("-c:a aac");
-    });
+        const scene = new Scene("test") as Scene & { path: string };
 
-    it("does not copy the audio stream", () => {
-      const scene = new Scene("test") as Scene & { path: string };
-      scene.meta.audioCodec = "unknown" as FFProbeAudioCodecs;
+        scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
 
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions).to.include("-c:a aac");
-    });
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:v h264_vaapi");
+      });
 
-    it("validates requirements", () => {
-      const scene = new Scene("test");
-      scene.meta.videoCodec = FFProbeVideoCodecs.H264;
+      it("applies bitrate params when necessary for amf", async function () {
+        await startTestServer.call(this, {
+          transcode: { hwaDriver: HardwareAccelerationDriver.enum.amf },
+        });
 
-      expect(new MP4Transcoder(scene).validateRequirements()).to.be.true;
-    });
+        const scene = new Scene("test") as Scene & { path: string };
+        scene.meta.bitrate = 1000;
 
-    it("validates requirements 2", () => {
-      const scene = new Scene("test");
-      scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
+        scene.meta.videoCodec = "unknown" as FFProbeVideoCodecs;
 
-      expect(new MP4Transcoder(scene).validateRequirements()).to.be.true;
-    });
+        const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
+        expect(outputOptions).to.include("-c:v h264_amf");
 
-    it("adds bitrate options", () => {
-      const scene = new Scene("test");
-      scene.meta.bitrate = 1000;
-
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions.some((opt) => opt.includes("-maxrate"))).to.be.true;
-    });
-
-    it("does not add bitrate options", () => {
-      const scene = new Scene("test");
-      scene.meta.bitrate = null;
-
-      const { outputOptions } = new MP4Transcoder(scene).getTranscodeOptions();
-      expect(outputOptions.some((opt) => opt.includes("-maxrate"))).to.be.false;
+        if (os.type() === "Windows_NT") {
+          expect(outputOptions.some((opt) => opt.includes("-maxrate"))).to.be.true;
+        } else {
+          expect(outputOptions.some((opt) => opt.includes("-maxrate"))).to.be.false;
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
- Drivers other than amf may not support bitrate options, so the ffmpeg transcode will fail. So far, we only know that amf on windows requires bitrate options. We can do more research if we ever want user selectable bitrates.
- Don't apply hardware encoder when the stream is already mp4 compatible