### PR TITLE
refactor(docker): use s6 service

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -14,9 +14,8 @@ COPY --from=build-env /app/releases/node14 /
 
 RUN apt-get update && apt-get  -y install ca-certificates ffmpeg &&  rm -rf /var/lib/apt/lists/*
 
-COPY ["config.example.json", "./docker/run.sh", "/"]
+COPY ["config.example.json", "./docker/root/", "/"]
 
 VOLUME [ "/config"]
 EXPOSE 3000
 ENV PV_CONFIG_FOLDER=/config
-ENTRYPOINT ["/run.sh"]

--- a/docker/root/etc/cont-init.d/40-init-dirs
+++ b/docker/root/etc/cont-init.d/40-init-dirs
@@ -1,0 +1,29 @@
+#!/usr/bin/with-contenv bash
+
+# We want a configuration file in /config so it can be stored in a persistent volume and not wiped out if we update the container.
+if [ ! -f /config/config.json ] && [ ! -f /config/config.yaml ]
+then
+	echo "copying example configuration to /config/config.json"
+	cp config.example.json /config/config.json
+fi
+
+if [ ! -d /videos ]
+then
+	mkdir /videos
+fi
+if [ ! -d /images ]
+then
+	mkdir /images
+fi
+
+# check Library permissions
+PUID=${PUID:-911}
+if [ ! "$(stat -c %u /config/library)" = "$PUID" ]; then
+	echo "Change in ownership detected, please be patient while we chown existing files"
+	echo "This could take some time"
+	chown abc:abc -R \
+	/config/library
+fi
+
+# set permissions non-recursively on config folders
+chown abc:abc /config /config/*

--- a/docker/root/etc/cont-init.d/40-init-dirs
+++ b/docker/root/etc/cont-init.d/40-init-dirs
@@ -7,23 +7,5 @@ then
 	cp config.example.json /config/config.json
 fi
 
-if [ ! -d /videos ]
-then
-	mkdir /videos
-fi
-if [ ! -d /images ]
-then
-	mkdir /images
-fi
-
-# check Library permissions
-PUID=${PUID:-911}
-if [ ! "$(stat -c %u /config/library)" = "$PUID" ]; then
-	echo "Change in ownership detected, please be patient while we chown existing files"
-	echo "This could take some time"
-	chown abc:abc -R \
-	/config/library
-fi
-
 # set permissions non-recursively on config folders
 chown abc:abc /config /config/*

--- a/docker/root/etc/cont-init.d/50-gid-video
+++ b/docker/root/etc/cont-init.d/50-gid-video
@@ -1,21 +1,5 @@
-#!/bin/sh
-# We want a configuration file in /config so it can be stored in a persistant volume and not wiped out if we update the container.
-if [ ! -f /config/config.json ] && [ ! -f /config/config.yaml ]
-then
-	echo "copying example configuration to /config/config.json"
-	cp config.example.json /config/config.json
-fi
+#!/usr/bin/with-contenv bash
 
-if [ ! -d /videos ]
-then
-	mkdir /videos
-fi
-if [ ! -d /images ]
-then
-	mkdir /images
-fi
-
-# Add our user the the card's group
 FILES=$(find /dev/dri /dev/dvb -type c -print 2>/dev/null)
 
 for i in $FILES
@@ -24,7 +8,7 @@ do
 	if id -G abc | grep -qw "$VIDEO_GID"; then
 		touch /groupadd
 	else
-		if [ ! "${VIDEO_GID}" = '0' ]; then
+		if [ ! "${VIDEO_GID}" == '0' ]; then
 			VIDEO_NAME=$(getent group "${VIDEO_GID}" | awk -F: '{print $1}')
 			if [ -z "${VIDEO_NAME}" ]; then
 				VIDEO_NAME="video$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c8)"
@@ -40,5 +24,3 @@ done
 if [ -n "${FILES}" ] && [ ! -f "/groupadd" ]; then
 	usermod -a -G root abc
 fi
-
-/porn-vault

--- a/docker/root/etc/services.d/porn-vault/finish
+++ b/docker/root/etc/services.d/porn-vault/finish
@@ -1,0 +1,5 @@
+#!/usr/bin/execlineb -S1
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/docker/root/etc/services.d/porn-vault/run
+++ b/docker/root/etc/services.d/porn-vault/run
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+
+echo "Starting Porn Vault"
+
+cd /
+exec s6-setuidgid abc /porn-vault


### PR DESCRIPTION
- Run porn-vault via an s6 service with the correct user
- Fixes files being created as `root` instead of the user defined by `PUID, PGID`